### PR TITLE
fixes bad falloff calculation

### DIFF
--- a/addons/ninetailsrabbit.terrainy/src/terrainy.gd
+++ b/addons/ninetailsrabbit.terrainy/src/terrainy.gd
@@ -274,10 +274,11 @@ func calculate_falloff(vertex: Vector3) -> float:
 	var falloff: float = 1.0
 	
 	if falloff_image:
-		var x_percent: float = (vertex.x + (size_width / 2)) / size_width
-		var z_percent: float = (vertex.z + (size_depth / 2)) / size_depth
-		var x_pixel: int = int(x_percent * falloff_image.get_width())
-		var y_pixel: int = int(z_percent * falloff_image.get_height())
+		var x_percent: float = clampf(((vertex.x + (size_width / 2)) / size_width), 0., 1.)
+		var z_percent: float = clampf(((vertex.z + (size_depth / 2)) / size_depth), 0., 1.)
+		
+		var x_pixel: int = int(x_percent * (falloff_image.get_width() - 1))
+		var y_pixel: int = int(z_percent * (falloff_image.get_height() - 1))
 		
 		# In this case we can go for any channel (r,g b) as the colors are the same
 		falloff = falloff_image.get_pixel(x_pixel, y_pixel).r


### PR DESCRIPTION
## Description

Fixes `Index p_<x or y> = 512 is out of bounds` errors caused by bad indexing in falloff logic. The original calculation has two issues:

1. The float values can drift from the expected <0.0; 1.0> range; I have not seen any values above 1.0 on my setup, but I have seen tiny negative values (on the order of -6*10e-7). This seems to come from vertices not being placed precisely in the min/max range - on a 100x100 gen, the lowest vertex is at coordinate -50.00006 rather than -50.0. I assume it's a classic floating point precision SNAFU somewhere.
2. Using max width/depth with 0-based indexing of texture pixels. Consider a tiny 2x2 texture. The four coordinates we can access are: (0, 0), (0, 1), (1, 0) and (1, 1). The current logic maps float percentage of 1.0 to max_width, which would be 2. So, if both X and Z are at 100%, this would map to... (2, 2) - which is out of bounds!

The fix is simple - clampf() the percentage to expected range to avoid float precision weirdness for (1), replacing raw width with (width - 1) and the same for depth to fix (2).

## Addressed issues

Fixes #1 

## Screenshots (Optional)

n/a
